### PR TITLE
Do not give error for tagged but unexported fields

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -54,7 +54,11 @@ func Example_structTagApproach() {
 		Opt2 []string  `flagparse:"usage=opt2 usage,nargs=2"`
 		Sw1  bool      `flagparse:"usage=sw1 usage,nargs=0"`
 	}{Opt1: -1}
-	fs, _ := flagparse.NewFlagSetFrom(&cfg)
+	fs, err := flagparse.NewFlagSetFrom(&cfg)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 	fmt.Printf("\nBefore parsing: %+v", cfg)
 	fs.CmdArgs = []string{"11", "1.1", "2.2", "--opt1-name", "22", "--opt2", "hello", "world", "--sw1"}
 	fs.Parse()

--- a/flagset.go
+++ b/flagset.go
@@ -81,7 +81,8 @@ func NewFlagSetFrom(src interface{}) (*FlagSet, error) {
 		fieldType := srcTyp.Field(i)
 		fieldVal := srcVal.Field(i)
 		structTags, tagged := srcTyp.Field(i).Tag.Lookup(packageTag)
-		if !tagged {
+		// ignore fields which are untagged and/or unexported
+		if !tagged || !fieldVal.Addr().CanInterface() {
 			continue
 		}
 
@@ -95,9 +96,6 @@ func NewFlagSetFrom(src interface{}) (*FlagSet, error) {
 			keyValues[nameKey] = strings.ToLower(fieldType.Name)
 		}
 
-		if !fieldVal.Addr().CanInterface() {
-			return nil, fmt.Errorf("Error while creating flag from field '%s': %s", fieldType.Name, "unexported struct field")
-		}
 		val, err := newValue(fieldVal.Addr().Interface())
 		if err != nil {
 			return nil, fmt.Errorf("Error while creating flag from field '%s': %s", fieldType.Name, err)

--- a/flagset_test.go
+++ b/flagset_test.go
@@ -56,7 +56,7 @@ func Test_Add_FlagToFlagSet(t *testing.T) {
 	}
 }
 
-func Test_NewArgSetFrom_InvalidInputs(t *testing.T) {
+func Test_NewFlagSetFrom_InvalidInputs(t *testing.T) {
 	data := []interface{}{
 		// Test nil as input
 		nil,
@@ -64,10 +64,6 @@ func Test_NewArgSetFrom_InvalidInputs(t *testing.T) {
 		*new(bool),
 		// Test pointer to a non-struct as input
 		new(bool),
-		// Test unexported tagged field as input
-		&struct {
-			field1 int `flagparse:""`
-		}{},
 		// Test unsupported field type as input
 		&struct {
 			Field1 int8 `flagparse:""`
@@ -88,12 +84,13 @@ func Test_NewArgSetFrom_InvalidInputs(t *testing.T) {
 	}
 }
 
-func Test_NewArgSetFrom_ValidInputs(t *testing.T) {
+func Test_NewFlagSetFrom_ValidInputs(t *testing.T) {
 	args := struct {
 		Field0 int // should get ignored
-		Field1 int `flagparse:""`           // expected an optional flag
-		Field2 int `flagparse:"positional"` // expected a positional flag
-	}{Field0: 11, Field1: 22, Field2: 33}
+		field1 int `flagparse:""`           // should get ignored
+		Field2 int `flagparse:""`           // expected an optional flag
+		Field3 int `flagparse:"positional"` // expected a positional flag
+	}{Field0: 11, field1: -1, Field2: 22, Field3: 33}
 
 	flagSet, err := NewFlagSetFrom(&args)
 	if err != nil {


### PR DESCRIPTION
Simply ignore any struct fields which are tagged but unexported.

Fixes #19