### PR TITLE
Make -h/--help names as reserved

### DIFF
--- a/flagset.go
+++ b/flagset.go
@@ -23,7 +23,8 @@ const (
 	nameKey          string = "name"
 	usageKey         string = "usage"
 	nargsKey         string = "nargs"
-	helpFlag         string = "--help"
+	helpShort        string = "-h"
+	helpLong         string = "--help"
 	packageTag       string = "flagparse"
 )
 
@@ -137,6 +138,9 @@ func (fs *FlagSet) Add(fl *Flag, name string, optNames ...string) error {
 		names := []string{name}
 		names = append(names, optNames...)
 		for _, nm := range names {
+			if nm == helpShort || nm == helpLong {
+				return fmt.Errorf("flag names %s,%s are reserved", helpShort, helpLong)
+			}
 			if !validOptName(nm) {
 				return fmt.Errorf("%q is not a valid optional flag name", nm)
 			}
@@ -241,7 +245,7 @@ func (fs *FlagSet) parse() error {
 		curArg := cmdArgs[iArgs]
 		switch curState {
 		case stateInit:
-			if curArg == helpFlag {
+			if curArg == helpShort || curArg == helpLong {
 				return &ErrHelpInvoked{}
 			}
 
@@ -376,7 +380,7 @@ func (fs *FlagSet) defaultUsage() {
 	}
 
 	fmt.Fprint(out, "\n\nOptional Flags:")
-	fmt.Fprintf(out, "\n  %s\n\t%s", helpFlag, "Show this usage message and exit")
+	fmt.Fprintf(out, "\n  %s, %s\n\t%s", helpShort, helpLong, "Show this usage message and exit")
 	for _, v := range fs.optMapToList() {
 		if v.fl.isSwitch() {
 			fmt.Fprintf(out, "\n\n  %s\n\t%s", v.name, v.fl.usage)

--- a/flagset_test.go
+++ b/flagset_test.go
@@ -70,6 +70,8 @@ func Test_FlagSet_Add_Invalid(t *testing.T) {
 		{fl: optFlag, name: defaultOptPrefix + "opt1"},
 		{fl: posFlag, name: defaultOptPrefix + "name-with-prefix"},
 		{fl: optFlag, name: "name-without-prefix"},
+		{fl: optFlag, name: helpLong},
+		{fl: optFlag, name: helpShort},
 		{optFlag, defaultOptPrefix + "name-with-prefix", []string{"opt-name-no-prefix"}},
 	}
 	for _, input := range data {
@@ -332,7 +334,7 @@ func Test_Parse_HelpOption(t *testing.T) {
 	fs.ContinueOnError = true
 	f, _ := os.Create(os.DevNull)
 	fs.SetOutput(f)
-	fs.CmdArgs = []string{helpFlag}
+	fs.CmdArgs = []string{helpLong}
 	err := fs.Parse()
 	if err == nil {
 		t.Errorf("Testing: FlagSet.Parse(); Expected: error with %q args; Got: no error", fs.CmdArgs)
@@ -358,7 +360,7 @@ func Test_Parse_ExitOnError(t *testing.T) {
 		arg      string
 		expected int
 	}{
-		{helpFlag, 1},
+		{helpLong, 1},
 		{"dummy-flag", 2},
 	}
 	for _, input := range data {


### PR DESCRIPTION
* Also invoke usage on both -h and --help
* Show both -h and --help in usage message

Fixes #13